### PR TITLE
Feature: actions in either list or bottom bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,14 @@ zig build run
 
 Binary at `zig-out/bin/zenkai`.
 
-## Run 
-For optimal results especially if you are using a Nvidia graphics card I've included `zenkai.sh` with some sane defaults that brings the RAM usage of the launcher down to 20-50MB 
+## Run
+
+For optimal results especially if you are using a Nvidia graphics card I've included `zenkai.sh` with some sane defaults that brings the RAM usage of the launcher down to 20-50MB
 
 *Your results may vary
 
+Flags: `--theme=dark|light`, `--no-icons`, `--no-bottom-bar`, `--show-actions` (parses `[Desktop Action ...]` sections for entries like "New Window", "New Private Window").
 
 ## Status
 
-v0.1. Core loop works — scan, search, filter. What's missing: no app launching, no icons in the list, theme switching isn't wired. Getting there.
+v0.1. Core loop works — scan, search, filter, launch. Flatpak/symlinks supported. Desktop actions behind `--show-actions`.

--- a/src/args/args.zig
+++ b/src/args/args.zig
@@ -8,6 +8,8 @@ pub const Config = struct {
     no_bottom_bar: bool,
     no_icons: bool,
     theme: ?[]const u8,
+    show_actions: bool,
+    actions_bottombar: bool,
 };
 
 pub fn parse(args: [][:0]u8) Config {
@@ -18,6 +20,8 @@ pub fn parse(args: [][:0]u8) Config {
         .no_bottom_bar = false,
         .no_icons = false,
         .theme = null,
+        .show_actions = false,
+        .actions_bottombar = false,
     };
 
     for (args) |arg_slice| {
@@ -39,6 +43,10 @@ pub fn parse(args: [][:0]u8) Config {
             cfg.no_icons = true;
         } else if (std.mem.eql(u8, arg, "--no-bottom-bar")) {
             cfg.no_bottom_bar = true;
+        } else if (std.mem.eql(u8, arg, "--show-actions")) {
+            cfg.show_actions = true;
+        } else if (std.mem.eql(u8, arg, "--actions-bottombar")) {
+            cfg.actions_bottombar = true;
         }
     }
 

--- a/src/core/actions.zig
+++ b/src/core/actions.zig
@@ -1,0 +1,109 @@
+const std = @import("std");
+const dapp_parser = @import("dapp_parser");
+const utils = @import("utils");
+
+pub const DesktopAction = struct {
+    id: []const u8,
+    name: []const u8,
+    exec: []const u8,
+    icon: ?[]const u8,
+};
+
+pub fn parseActions(allocator: std.mem.Allocator, content: []const u8, action_ids: [][]const u8) ![]DesktopAction {
+    var actions = std.ArrayList(DesktopAction).empty;
+    errdefer {
+        for (actions.items) |a| {
+            allocator.free(a.id);
+            allocator.free(a.name);
+            allocator.free(a.exec);
+            if (a.icon) |ic| allocator.free(ic);
+        }
+        actions.deinit(allocator);
+    }
+
+    var entry_iter = dapp_parser.desktopEntryIterator(content);
+    while (entry_iter.next()) |section| {
+        const section_name = extractSectionName(section) orelse continue;
+        if (utils.log.verbose) utils.log.info("  section: '{s}'", .{section_name});
+        const action_id = stripDesktopActionPrefix(section_name) orelse continue;
+
+        const is_wanted = for (action_ids) |id| {
+            if (std.mem.eql(u8, id, action_id)) break true;
+        } else false;
+        if (!is_wanted) continue;
+
+        var name: ?[]const u8 = null;
+        var exec: ?[]const u8 = null;
+        var icon: ?[]const u8 = null;
+
+        var line_iter = dapp_parser.lineIterator(section);
+        while (line_iter.next()) |line| {
+            const trimmed = std.mem.trim(u8, line, " \t\r\n");
+            if (trimmed.len == 0 or trimmed[0] == '#') continue;
+            const kv = splitToKV(trimmed) orelse continue;
+            if (std.mem.indexOfScalar(u8, kv.key, '[') != null) continue;
+
+            if (utils.strcomp(kv.key, "Name")) {
+                name = kv.value;
+            } else if (utils.strcomp(kv.key, "Exec")) {
+                exec = if (kv.value.len > 0) kv.value else null;
+            } else if (utils.strcomp(kv.key, "Icon")) {
+                icon = if (kv.value.len > 0) kv.value else null;
+            }
+        }
+
+        if (name == null or exec == null) {
+            if (utils.log.verbose) utils.log.info("action '{s}' skipped: name={?s} exec={?s}", .{ action_id, name, exec });
+            continue;
+        }
+
+        try actions.append(allocator, .{
+            .id = try allocator.dupe(u8, action_id),
+            .name = try allocator.dupe(u8, name.?),
+            .exec = try allocator.dupe(u8, exec.?),
+            .icon = if (icon) |ic| try allocator.dupe(u8, ic) else null,
+        });
+    }
+
+    if (utils.log.verbose) utils.log.info("parseActions: found {d} actions for {d} requested ids", .{ actions.items.len, action_ids.len });
+    return try actions.toOwnedSlice(allocator);
+}
+
+pub fn deinitActions(allocator: std.mem.Allocator, actions: []DesktopAction) void {
+    for (actions) |a| {
+        allocator.free(a.id);
+        allocator.free(a.name);
+        allocator.free(a.exec);
+        if (a.icon) |ic| allocator.free(ic);
+    }
+    allocator.free(actions);
+}
+
+fn extractSectionName(section: []const u8) ?[]const u8 {
+    var line_iter = dapp_parser.lineIterator(section);
+    while (line_iter.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, " \t\r\n");
+        if (trimmed.len > 0 and trimmed[0] == '[') {
+            const close = std.mem.indexOfScalar(u8, trimmed, ']') orelse continue;
+            return trimmed[1..close];
+        }
+    }
+    return null;
+}
+
+fn stripDesktopActionPrefix(section_name: []const u8) ?[]const u8 {
+    const prefix = "Desktop Action ";
+    if (std.mem.startsWith(u8, section_name, prefix)) {
+        return section_name[prefix.len..];
+    }
+    return null;
+}
+
+fn splitToKV(line: []const u8) ?struct { key: []const u8, value: []const u8 } {
+    if (std.mem.indexOfScalar(u8, line, '=')) |eq_pos| {
+        const key = std.mem.trim(u8, line[0..eq_pos], " \t");
+        const value = std.mem.trim(u8, line[eq_pos + 1 ..], " \t");
+        return .{ .key = key, .value = value };
+    }
+    return null;
+}

--- a/src/core/dapp_parser.zig
+++ b/src/core/dapp_parser.zig
@@ -13,6 +13,7 @@ pub const DappParser = struct {
         var entry_iter = desktopEntryIterator(content);
 
         while (entry_iter.next()) |entry| {
+            if (!isDesktopEntry(entry)) continue;
             var line_iter = lineIterator(entry);
             while (line_iter.next()) |line| {
                 const trimmed = std.mem.trim(u8, line, " \t\r\n");
@@ -181,15 +182,12 @@ pub const DesktopEntryIterator = struct {
 
             const trimmed = std.mem.trim(u8, raw_line, " \t");
 
-            if (std.mem.startsWith(u8, trimmed, "[Desktop Entry]")) {
+            if (trimmed.len > 0 and trimmed[0] == '[') {
                 if (start != null) {
-                    const section = self.source[start.?..line_start];
-                    return section;
+                    self.index = line_start;
+                    return self.source[start.?..line_start];
                 }
                 start = line_start;
-            } else if (start != null and trimmed.len > 0 and trimmed[0] == '[') {
-                const section = self.source[start.?..line_start];
-                return section;
             }
         }
 
@@ -202,3 +200,13 @@ pub const DesktopEntryIterator = struct {
         return null;
     }
 };
+
+pub fn isDesktopEntry(section: []const u8) bool {
+    var iter = lineIterator(section);
+    while (iter.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, " \t\r\n");
+        if (trimmed.len == 0) continue;
+        return std.mem.startsWith(u8, trimmed, "[Desktop Entry]");
+    }
+    return false;
+}

--- a/src/core/desktop_loader.zig
+++ b/src/core/desktop_loader.zig
@@ -1,43 +1,126 @@
 const std = @import("std");
 const platform = @import("platform.zig");
+const de = @import("desktopapp");
+const appreader = @import("appreader.zig");
 const ui = @import("../ui/ui.zig");
 const debug = @import("../debug/debug.zig");
+const actions_mod = @import("actions.zig");
+const fsutils = @import("utils").fsutils;
 
 pub const Error = error{ LoadFailed, ScanFailed };
 
-pub fn load(allocator: std.mem.Allocator, benchmark: bool) ![]ui.ListItem {
+var g_reader: ?appreader.AppReader = null;
+
+pub fn getDesktopApps() []const de.DesktopApp {
+    if (g_reader) |*r| return r.apps.items;
+    return &.{};
+}
+
+pub fn freeDesktopApps() void {
+    if (g_reader) |*r| r.deinit();
+    g_reader = null;
+}
+
+fn parseAndStoreActions(allocator: std.mem.Allocator, da: *const de.DesktopApp, actions_out: *std.ArrayList(ui.ListItemAction)) !void {
+    if (da.file_path) |fp| {
+        const content = fsutils.readFile(allocator, fp) catch return;
+        defer allocator.free(content);
+
+        const parsed = actions_mod.parseActions(allocator, content, da.actions) catch return;
+        defer actions_mod.deinitActions(allocator, parsed);
+
+        for (parsed) |action| {
+            try actions_out.append(allocator, .{
+                .name = try allocator.dupe(u8, action.name),
+                .exec = try allocator.dupe(u8, action.exec),
+                .icon = if (action.icon) |ic| try allocator.dupe(u8, ic) else try allocator.dupe(u8, if (da.icon) |ic2| ic2 else ""),
+            });
+        }
+    }
+}
+
+pub fn freeListItemActions(allocator: std.mem.Allocator, actions: []const ui.ListItemAction) void {
+    for (actions) |a| {
+        allocator.free(a.name);
+        allocator.free(a.exec);
+        allocator.free(a.icon);
+    }
+    allocator.free(actions);
+}
+
+fn makeListItem(allocator: std.mem.Allocator, da: *const de.DesktopApp, actions: []const ui.ListItemAction, app_idx: usize) !ui.ListItem {
+    return .{
+        .icon = try allocator.dupe(u8, if (da.icon) |ic| ic else ""),
+        .cmd = try allocator.dupe(u8, if (da.exec) |e| e else ""),
+        .name = try allocator.dupe(u8, da.name),
+        .actions = actions,
+        .desktop_app_idx = app_idx,
+    };
+}
+
+pub fn load(allocator: std.mem.Allocator, benchmark: bool, show_actions: bool, actions_bottombar: bool) ![]ui.ListItem {
     if (benchmark) debug.mark("reader load");
+    freeDesktopApps();
+
     var reader = platform.AppReader.init(allocator);
     defer reader.deinit();
     reader.load() catch {
+        reader.deinit();
         ui.showError("Error loading desktop files");
         return Error.LoadFailed;
     };
 
     if (benchmark) debug.mark("reader scan");
     reader.scan() catch {
+        reader.deinit();
         ui.showError("Error parsing desktop files");
         return Error.ScanFailed;
     };
 
     if (benchmark) debug.mark("list init");
-    const items = try allocator.alloc(ui.ListItem, reader.apps.items.len);
-    errdefer allocator.free(items);
 
-    var i: usize = 0;
-    errdefer for (0..i) |j| {
-        allocator.free(items[j].icon);
-        allocator.free(items[j].cmd);
-        allocator.free(items[j].name);
-    };
+    const need_actions = actions_bottombar or show_actions;
+    const show_list_actions = show_actions and !actions_bottombar;
 
-    for (reader.apps.items, 0..) |da, idx| {
-        i = idx;
-        items[idx] = .{
-            .icon = try allocator.dupe(u8, if (da.icon) |ic| ic else ""),
-            .cmd = try allocator.dupe(u8, if (da.exec) |e| e else ""),
-            .name = try allocator.dupe(u8, da.name),
-        };
+    var all_items = std.ArrayList(ui.ListItem).empty;
+    errdefer {
+        for (all_items.items) |item| {
+            allocator.free(item.icon);
+            allocator.free(item.cmd);
+            allocator.free(item.name);
+            if (item.actions.len > 0) freeListItemActions(allocator, item.actions);
+        }
+        all_items.deinit(allocator);
+        reader.deinit();
     }
-    return items;
+
+    g_reader = reader;
+
+    for (reader.apps.items, 0..) |*da, app_idx| {
+        if (need_actions and da.actions.len > 0) {
+            var action_list = std.ArrayList(ui.ListItemAction).empty;
+            parseAndStoreActions(allocator, da, &action_list) catch {};
+            const action_slice = try action_list.toOwnedSlice(allocator);
+
+            try all_items.append(allocator, try makeListItem(allocator, da, action_slice, app_idx));
+
+            if (show_list_actions) {
+                for (action_slice) |action_item| {
+                    const label = try std.fmt.allocPrint(allocator, "{s}: {s}", .{ da.name, action_item.name });
+                    const cmd = try allocator.dupe(u8, action_item.exec);
+                    const icon = try allocator.dupe(u8, action_item.icon);
+                    try all_items.append(allocator, .{
+                        .icon = icon,
+                        .cmd = cmd,
+                        .name = label,
+                        .desktop_app_idx = app_idx,
+                    });
+                }
+            }
+        } else {
+            try all_items.append(allocator, try makeListItem(allocator, da, &.{}, app_idx));
+        }
+    }
+
+    return try all_items.toOwnedSlice(allocator);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -21,19 +21,21 @@ pub fn main(init: std.process.Init) !void {
     var pm = plugins.setup(init.gpa);
     defer pm.deinit();
 
-    const items = try desktop_loader.load(init.gpa, ctx.cfg.benchmark_all);
+    const items = try desktop_loader.load(init.gpa, ctx.cfg.benchmark_all, ctx.cfg.show_actions, ctx.cfg.actions_bottombar);
     defer {
         for (items) |item| {
             init.gpa.free(item.icon);
             init.gpa.free(item.cmd);
             init.gpa.free(item.name);
+            if (item.actions.len > 0) desktop_loader.freeListItemActions(init.gpa, item.actions);
         }
         init.gpa.free(items);
+        desktop_loader.freeDesktopApps();
     }
 
     if (ctx.cfg.benchmark_all) debug.mark("window setup");
     var window: ui.Window = undefined;
-    ui.renderList(&window, init.gpa, items, ctx.cfg.icon_size, !ctx.cfg.no_bottom_bar, ctx.cfg.no_icons);
+    ui.renderList(&window, init.gpa, items, ctx.cfg.icon_size, !ctx.cfg.no_bottom_bar, ctx.cfg.no_icons, ctx.cfg.actions_bottombar);
     window.list.plugin_manager = &pm;
     defer window.deinit();
 

--- a/src/ui/bottombar.zig
+++ b/src/ui/bottombar.zig
@@ -1,11 +1,13 @@
 const std = @import("std");
 const qt = @import("libqt6zig");
 const applist = @import("list.zig");
+const ListItemAction = @import("list.zig").ListItemAction;
 const info = @import("info.zig");
 
 const HBoxLayout = qt.QHBoxLayout;
 const QAction = qt.QAction;
 const QToolButton = qt.QToolButton;
+const QShortcut = qt.QShortcut;
 const QKeySequence = qt.QKeySequence;
 const QIcon = qt.QIcon;
 const QLabel = qt.QLabel;
@@ -31,6 +33,7 @@ pub const BottomBar = struct {
     actions: []QAction,
     items: []QWidget,
     parent: QWidget,
+    info_shortcut: QShortcut,
 
     pub fn init(allocator: std.mem.Allocator, parent: qt.QWidget) BottomBar {
         const container = QWidget.New2();
@@ -45,12 +48,21 @@ pub const BottomBar = struct {
             .actions = &.{},
             .items = &.{},
             .parent = parent,
+            .info_shortcut = undefined,
         };
     }
 
     pub fn setup(self: *BottomBar, list: *applist.List) void {
         g_app_list = list;
         info.setup(list, self.parent);
+        const seq = QKeySequence.New2("Ctrl+I");
+        defer seq.Delete();
+        self.info_shortcut = QShortcut.New2(seq, self.parent);
+        self.info_shortcut.OnActivated(struct {
+            fn handler(_: QShortcut) callconv(.c) void {
+                info.showInfoPanel();
+            }
+        }.handler);
     }
 
     fn removeActions(self: *BottomBar) void {
@@ -106,6 +118,41 @@ pub const BottomBar = struct {
         self.setActions(&.{});
     }
 
+    pub fn setItemActions(self: *BottomBar, actions: []const ListItemAction) void {
+        self.removeItems();
+        self.removeActions();
+
+        const n = @min(actions.len, 10);
+        if (n == 0) {
+            self.setDefaultActions();
+            return;
+        }
+
+        self.actions = &.{};
+        self.items = self.allocator.alloc(QWidget, n) catch return;
+
+        for (actions[0..n], 0..) |a, i| {
+            const el = QWidget.New2();
+            var row = HBoxLayout.New(el);
+            row.SetContentsMargins(0, 0, 0, 0);
+            row.SetSpacing(4);
+
+            var buf: [8]u8 = undefined;
+            const shortcut_str = if (i < 9)
+                std.fmt.bufPrint(&buf, "Ctrl+{d}", .{i + 1}) catch "?"
+            else
+                std.fmt.bufPrint(&buf, "Ctrl+0", .{}) catch "?";
+            const shortcut_label = QLabel.New3(shortcut_str);
+            row.AddWidget(shortcut_label);
+
+            const name_label = QLabel.New3(a.name);
+            row.AddWidget(name_label);
+
+            self.layout.AddWidget(el);
+            self.items[i] = el;
+        }
+    }
+
     pub fn setActions(self: *BottomBar, actions: []const Action) void {
         self.removeItems();
         self.removeActions();
@@ -133,7 +180,7 @@ pub const BottomBar = struct {
             {
                 const icon = QIcon.FromTheme("dialog-information");
                 defer icon.Delete();
-                self.actions[1] = self.buildAction(icon, "Info", "Ctrl+I", info.onInfo);
+                self.actions[1] = self.buildAction(icon, "Info", "", info.onInfo);
                 self.items[1] = self.buildItem(self.actions[1], "Ctrl+I");
             }
         }

--- a/src/ui/info.zig
+++ b/src/ui/info.zig
@@ -3,6 +3,7 @@ const qt = @import("libqt6zig");
 const theme = @import("../theme/theme.zig");
 const applist = @import("list.zig");
 const de = @import("desktopapp");
+const desktop_loader = @import("../core/desktop_loader.zig");
 const utils = @import("utils");
 
 const QAction = qt.QAction;
@@ -24,17 +25,20 @@ fn currentApp() ?*const de.DesktopApp {
     if (!idx.IsValid()) return null;
     const row = @as(usize, @intCast(idx.Row()));
     if (row >= g_list.indices.items.len) return null;
-    return switch (g_list.source) {
-        .desktop_apps => |apps| {
-            const entry = g_list.indices.items[row];
-            const app_idx = switch (entry) {
-                .item => |i| i,
-                .plugin => return null,
-            };
-            return &apps[app_idx];
-        },
-        .items => null,
+    const entry = g_list.indices.items[row];
+    const item_idx = switch (entry) {
+        .item => |i| i,
+        .plugin => return null,
     };
+    const da_idx = switch (g_list.source) {
+        .desktop_apps => |apps| {
+            return &apps[item_idx];
+        },
+        .items => |items| items[item_idx].desktop_app_idx orelse return null,
+    };
+    const apps = desktop_loader.getDesktopApps();
+    if (da_idx < apps.len) return &apps[da_idx];
+    return null;
 }
 
 fn loadAppIcon(icon_name: ?[]const u8) QIcon {
@@ -121,6 +125,10 @@ const Html = struct {
 };
 
 pub fn onInfo(_: QAction) callconv(.c) void {
+    showInfoPanel();
+}
+
+pub fn showInfoPanel() void {
     const app = currentApp() orelse return;
 
     var html = Html{ .buf = .empty, .gpa = g_list.allocator };

--- a/src/ui/keyboard.zig
+++ b/src/ui/keyboard.zig
@@ -1,5 +1,7 @@
+const std = @import("std");
 const qt = @import("libqt6zig");
 const List = @import("list.zig").List;
+const utils = @import("utils");
 
 const QShortcut = qt.QShortcut;
 const QKeySequence = qt.QKeySequence;
@@ -40,6 +42,19 @@ fn onEscape(_: QShortcut) callconv(.c) void {
     QApp.Quit();
 }
 
+fn makeActionHandler(comptime n: usize) *const fn (QShortcut) callconv(.c) void {
+    const H = struct {
+        fn handler(_: QShortcut) callconv(.c) void {
+            const actions = List.currentItemActions();
+            if (n < actions.len) {
+                utils.execute(actions[n].exec, L.allocator) catch {};
+                QApp.Quit();
+            }
+        }
+    };
+    return H.handler;
+}
+
 pub const Keyboard = struct {
     pub fn setup(window: QWidget, list: *List) void {
         L = list;
@@ -47,5 +62,9 @@ pub const Keyboard = struct {
         bind(window, "Up", onUp);
         bind(window, "Down", onDown);
         bind(window, "Escape", onEscape);
+        inline for (0..10) |i| {
+            var key_buf: [6]u8 = .{ 'C', 't', 'r', 'l', '+', if (i < 9) '1' + @as(u8, @intCast(i)) else '0' };
+            bind(window, &key_buf, makeActionHandler(i));
+        }
     }
 };

--- a/src/ui/list.zig
+++ b/src/ui/list.zig
@@ -18,6 +18,12 @@ const QRect = qt.QRect;
 const QFont = qt.QFont;
 const QApp = qt.QApplication;
 
+pub const ListItemAction = struct {
+    name: []const u8,
+    exec: []const u8,
+    icon: []const u8,
+};
+
 var g_icon_size: i32 = 32;
 var g_no_icons: bool = false;
 
@@ -131,6 +137,8 @@ pub const ListItem = struct {
     icon: []const u8,
     cmd: []const u8,
     name: []const u8,
+    actions: []const ListItemAction = &.{},
+    desktop_app_idx: ?usize = null,
 };
 
 const DataSource = union(enum) {
@@ -153,6 +161,31 @@ fn freePluginResults(allocator: std.mem.Allocator, results: *std.ArrayList(plugi
 }
 
 var g_list: *List = undefined;
+var g_on_item_focused: ?*const fn (item_index: usize, actions: []const ListItemAction) void = null;
+var g_current_item_actions: []const ListItemAction = &.{};
+
+fn onCurrentChanged(_: QListView, current: QModelIndex, _: QModelIndex) callconv(.c) void {
+    const row = current.Row();
+    if (row < 0) return;
+    const urow = @as(usize, @intCast(row));
+    if (urow >= g_list.indices.items.len) return;
+
+    const entry = g_list.indices.items[urow];
+    switch (entry) {
+        .item => |item_idx| {
+            const items = switch (g_list.source) {
+                .items => |is| is,
+                .desktop_apps => return,
+            };
+            g_current_item_actions = items[item_idx].actions;
+            if (g_on_item_focused) |cb| cb(item_idx, items[item_idx].actions);
+        },
+        .plugin => {
+            g_current_item_actions = &.{};
+            if (g_on_item_focused) |cb| cb(0, &.{});
+        },
+    }
+}
 
 fn onRowCount(_: QAbstractListModel, _: QModelIndex) callconv(.c) i32 {
     return @intCast(g_list.indices.items.len);
@@ -235,6 +268,7 @@ pub const List = struct {
         defer icon_sz.Delete();
         view.SetIconSize(icon_sz);
         view.SetModel(model);
+        view.OnCurrentChanged(onCurrentChanged);
 
         return .{
             .allocator = allocator,
@@ -245,6 +279,14 @@ pub const List = struct {
             .plugin_results = std.ArrayList(plugins.PluginResult).empty,
             .plugin_manager = plugin_manager,
         };
+    }
+
+    pub fn setOnItemFocused(callback: *const fn (item_index: usize, actions: []const ListItemAction) void) void {
+        g_on_item_focused = callback;
+    }
+
+    pub fn currentItemActions() []const ListItemAction {
+        return g_current_item_actions;
     }
 
     fn sourceLen(self: *const List) usize {

--- a/src/ui/ui.zig
+++ b/src/ui/ui.zig
@@ -3,6 +3,7 @@ const qt = @import("libqt6zig");
 
 pub const List = @import("list.zig").List;
 pub const ListItem = @import("list.zig").ListItem;
+pub const ListItemAction = @import("list.zig").ListItemAction;
 pub const Keyboard = @import("keyboard.zig").Keyboard;
 pub const BottomBar = @import("bottombar.zig").BottomBar;
 pub const Window = @import("window.zig").Window;
@@ -35,6 +36,7 @@ pub fn renderList(
     icon_size: i32,
     show_bottom_bar: bool,
     no_icons: bool,
+    actions_bottombar: bool,
 ) void {
-    self.init(allocator, items, icon_size, !show_bottom_bar, no_icons);
+    self.init(allocator, items, icon_size, !show_bottom_bar, no_icons, actions_bottombar);
 }

--- a/src/ui/window.zig
+++ b/src/ui/window.zig
@@ -3,6 +3,7 @@ const qt = @import("libqt6zig");
 
 const List = @import("list.zig").List;
 const ListItem = @import("list.zig").ListItem;
+const ListItemAction = @import("list.zig").ListItemAction;
 const Keyboard = @import("keyboard.zig").Keyboard;
 const BottomBar = @import("bottombar.zig").BottomBar;
 
@@ -52,6 +53,7 @@ pub const Window = struct {
         icon_size: i32,
         no_bottom_bar: bool,
         no_icons: bool,
+        actions_bottombar: bool,
     ) void {
         List.setNoIcons(no_icons);
 
@@ -100,6 +102,14 @@ pub const Window = struct {
             bar.setDefaultActions();
             main_layout.AddWidget(bar.container);
             self.bottom_bar = bar;
+        }
+
+        if (actions_bottombar and !no_bottom_bar) {
+            List.setOnItemFocused(struct {
+                fn callback(_: usize, actions: []const ListItemAction) void {
+                    if (g_window.bottom_bar) |*bar| bar.setItemActions(actions);
+                }
+            }.callback);
         }
 
         window.SetMinimumSize2(win_w, win_h);

--- a/src/utils/fsutils.zig
+++ b/src/utils/fsutils.zig
@@ -53,6 +53,21 @@ pub fn makeDir(io: std.Io, path: []const u8) !void {
     try std.Io.Dir.createDirAbsolute(io, path, .default_dir);
 }
 
+pub fn readFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    const io = std.Io.Threaded.io(std.Io.Threaded.global_single_threaded);
+    const cwd = std.Io.Dir.cwd();
+    const file = try std.Io.Dir.openFile(cwd, io, path, .{});
+    defer std.Io.File.close(file, io);
+
+    const stat = try std.Io.Dir.statFile(cwd, io, path, .{});
+    const size = @as(usize, @intCast(stat.size));
+    if (size > 2 * 1024 * 1024) return error.FileTooBig;
+
+    var buf: [4096]u8 = undefined;
+    var reader = std.Io.File.Reader.init(file, io, &buf);
+    return try reader.interface.readAlloc(allocator, size);
+}
+
 fn readDirInternal(
     allocator: std.mem.Allocator,
     dir_path: []const u8,


### PR DESCRIPTION
## Features
- Actions supported
On Linux Zenkai will now parse actions and if given the `--show-actions` flag show them in the list so for example firefox will yield, firefox, firefox new window, firefox incognito window and firefox profile manager.
- Flag `--actions-bottombar` will place actions in the bottom bar and allow the user to access them via ctrl+1-0

<img width="943" height="805" alt="image" src="https://github.com/user-attachments/assets/0f5a578a-3e02-4e1f-a218-69437ed123d1" />
 