### PR TITLE
fix: add close-on-focus-out and show-backdrop features

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -58,6 +58,7 @@ pub fn build(b: *std.Build) void {
         "qtoolbutton",
         "qlistview",
         "qtimer",
+        "qcursor",
     };
 
     for (libs) |lib| {

--- a/src/args/args.zig
+++ b/src/args/args.zig
@@ -19,6 +19,9 @@ pub const help =
     \\  --show-actions            Show item actions
     \\  --actions-bottombar       Show actions in bottom bar
     \\  --list-themes             List all available themes with descriptions
+    \\  --close-on-focus-out     Close the launcher when it loses focus
+    \\  --no-close-on-focus-out  Keep the launcher open when it loses focus
+    \\  --show-backdrop           Show a backdrop to detect clicks outside the launcher
     \\  --help, -h                Show this help and exit
 ;
 
@@ -33,6 +36,8 @@ pub const Config = struct {
     show_actions: bool,
     actions_bottombar: bool,
     list_themes: bool,
+    close_on_focus_out: ?bool,
+    show_backdrop: bool,
     window_width: ?i32,
     window_height: ?i32,
 };
@@ -101,6 +106,8 @@ pub fn parse(args: [][:0]u8) Config {
         .show_actions = false,
         .actions_bottombar = false,
         .list_themes = false,
+        .close_on_focus_out = null,
+        .show_backdrop = false,
         .window_width = null,
         .window_height = null,
     };
@@ -137,6 +144,12 @@ pub fn parse(args: [][:0]u8) Config {
             cfg.show_actions = true;
         } else if (std.mem.eql(u8, arg, "--actions-bottombar")) {
             cfg.actions_bottombar = true;
+        } else if (std.mem.eql(u8, arg, "--close-on-focus-out")) {
+            cfg.close_on_focus_out = true;
+        } else if (std.mem.eql(u8, arg, "--no-close-on-focus-out")) {
+            cfg.close_on_focus_out = false;
+        } else if (std.mem.eql(u8, arg, "--show-backdrop")) {
+            cfg.show_backdrop = true;
         } else if (std.mem.eql(u8, arg, "--list-themes")) {
             cfg.list_themes = true;
         }

--- a/src/config/config.toml
+++ b/src/config/config.toml
@@ -13,6 +13,12 @@ icon_size = 32
 # Theme: pass via --theme CLI flag (e.g. --theme=minimal)
 # Built-in themes: dark, light, dracula, ayu-dark, minimal
 
+# Close launcher when it loses focus (e.g. clicking outside)
+close_on_focus_out = false
+
+# Show a transparent backdrop covering the full screen to catch clicks outside
+show_backdrop = false
+
 # -- Bottom bar (action buttons bar) ------------------------------------------
 bottom_bar_margin_top = 4
 bottom_bar_margin_bottom = 4

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -10,11 +10,15 @@ pub const VisualConfig = struct {
     layout_margin: i32 = 0,
     layout_spacing: i32 = 0,
     icon_size: i32 = 32,
+    close_on_focus_out: bool = false,
+    show_backdrop: bool = false,
 
     pub fn applyOverrides(self: *VisualConfig, cfg: anytype) void {
         if (cfg.window_width) |v| self.window_width = v;
         if (cfg.window_height) |v| self.window_height = v;
         if (cfg.icon_size) |v| self.icon_size = v;
+        if (cfg.close_on_focus_out) |v| self.close_on_focus_out = v;
+        if (cfg.show_backdrop) self.show_backdrop = true;
     }
 };
 
@@ -83,6 +87,8 @@ pub fn loadConfig(allocator: std.mem.Allocator, config_path: []const u8) !Visual
         if (std.mem.eql(u8, key, "layout_margin")) cfg.layout_margin = parseInt(val) catch continue;
         if (std.mem.eql(u8, key, "layout_spacing")) cfg.layout_spacing = parseInt(val) catch continue;
         if (std.mem.eql(u8, key, "icon_size")) cfg.icon_size = parseInt(val) catch continue;
+        if (std.mem.eql(u8, key, "close_on_focus_out")) cfg.close_on_focus_out = std.mem.eql(u8, val, "true");
+        if (std.mem.eql(u8, key, "show_backdrop")) cfg.show_backdrop = std.mem.eql(u8, val, "true");
     }
 
     return cfg;

--- a/src/core/bootstrap.zig
+++ b/src/core/bootstrap.zig
@@ -36,7 +36,6 @@ pub fn init(allocator: std.mem.Allocator, raw_args: anytype) !Context {
 
     var visual = try config.loadConfig(allocator, config_path);
     visual.applyOverrides(cfg);
-    if (cfg.icon_size) |s| visual.icon_size = s;
 
     const theme_resolved = theme.resolve(allocator, cfg.theme);
     defer if (theme_resolved.allocation) |m| allocator.free(m);

--- a/src/main.zig
+++ b/src/main.zig
@@ -89,7 +89,7 @@ pub fn main(init: std.process.Init) !void {
 
     if (ctx.cfg.benchmark_all) debug.mark("window setup");
     var window: ui.Window = undefined;
-    ui.renderList(&window, init.gpa, items, ctx.visual, !ctx.cfg.no_bottom_bar, ctx.cfg.no_icons);
+    ui.renderList(&window, init.gpa, items, ctx.visual, !ctx.cfg.no_bottom_bar, ctx.cfg.no_icons, ctx.app);
     window.list.plugin_manager = &pm;
     defer window.deinit();
 

--- a/src/ui/ui.zig
+++ b/src/ui/ui.zig
@@ -38,6 +38,7 @@ pub fn renderList(
     vis: config.VisualConfig,
     show_bottom_bar: bool,
     no_icons: bool,
+    app: QApp,
 ) void {
-    self.init(allocator, items, vis, !show_bottom_bar, no_icons);
+    self.init(allocator, items, vis, !show_bottom_bar, no_icons, app);
 }

--- a/src/ui/window.zig
+++ b/src/ui/window.zig
@@ -14,6 +14,47 @@ const QVBoxLayout = qt.QVBoxLayout;
 const QCloseEvent = qt.QCloseEvent;
 
 var g_window: *Window = undefined;
+var g_close_on_focus_out: bool = false;
+var g_blur_timer: qt.QTimer = undefined;
+var g_mouse_left_at: i64 = 0;
+var g_backdrop: ?QWidget = null;
+var g_backdrop_geo: [4]i32 = .{ 0, 0, 0, 0 };
+
+fn nanoTimestamp() i64 {
+    var ts: std.c.timespec = undefined;
+    _ = std.c.clock_gettime(std.c.CLOCK.MONOTONIC, &ts);
+    return @as(i64, ts.sec) * std.time.ns_per_s + @as(i64, ts.nsec);
+}
+
+fn onAppStateChanged(_: QApp, state: i32) callconv(.c) void {
+    if (!g_close_on_focus_out) return;
+    if (state == 2) {
+        const elapsed = nanoTimestamp() - g_mouse_left_at;
+        if (elapsed > 100_000_000) {
+            g_blur_timer.Start(200);
+        }
+    } else if (state == 4) {
+        g_blur_timer.Stop();
+    }
+}
+
+fn onLeaveWidget(_: QWidget, _: qt.QEvent) callconv(.c) void {
+    g_mouse_left_at = nanoTimestamp();
+}
+
+fn onBlurTimerTimeout(_: qt.QTimer) callconv(.c) void {
+    QApp.Quit();
+}
+
+fn onBackdropClick(_: qt.QWidget, _: qt.QMouseEvent) callconv(.c) void {
+    QApp.Quit();
+}
+
+fn onBackdropMove(_: qt.QWidget, _: qt.QMoveEvent) callconv(.c) void {
+    if (g_backdrop) |bd| {
+        bd.SetGeometry(g_backdrop_geo[0], g_backdrop_geo[1], g_backdrop_geo[2], g_backdrop_geo[3]);
+    }
+}
 
 fn onSearchDebounced(text: []const u8) void {
     g_window.list.setFilter(text);
@@ -21,6 +62,13 @@ fn onSearchDebounced(text: []const u8) void {
 
 fn onWindowClose(_: QWidget, _: QCloseEvent) callconv(.c) void {
     QApp.Quit();
+}
+
+fn closeBackdrop() void {
+    if (g_backdrop) |bd| {
+        bd.Delete();
+        g_backdrop = null;
+    }
 }
 
 pub const Window = struct {
@@ -37,16 +85,45 @@ pub const Window = struct {
         vis: config.VisualConfig,
         no_bottom_bar: bool,
         no_icons: bool,
+        app: QApp,
     ) void {
         List.setNoIcons(no_icons);
 
         const win_w: i32 = @max(vis.window_width, 200);
         const win_h: i32 = @max(vis.window_height, 200);
 
+        const wt = qt.qnamespace_enums.WindowType;
+
+        const cursor_pos = qt.QCursor.Pos();
+        const screen_rect = QApp.ScreenAt(cursor_pos).Geometry();
+        const screen_w = screen_rect.Width();
+        const screen_h = screen_rect.Height();
+
+        if (vis.show_backdrop) {
+            const bd = QWidget.New2();
+            bd.SetWindowTitle("zenkai-backdrop");
+            bd.SetWindowFlags(
+                wt.Tool |
+                    wt.FramelessWindowHint |
+                    wt.BypassWindowManagerHint |
+                    wt.NoDropShadowWindowHint |
+                    wt.WindowDoesNotAcceptFocus |
+                    wt.WindowStaysOnBottomHint,
+            );
+            bd.SetAttribute2(qt.qnamespace_enums.WidgetAttribute.WA_TranslucentBackground, true);
+            bd.SetAttribute2(qt.qnamespace_enums.WidgetAttribute.WA_NoSystemBackground, true);
+
+            g_backdrop_geo = .{ screen_rect.X(), screen_rect.Y(), screen_w, screen_h };
+            bd.SetGeometry(g_backdrop_geo[0], g_backdrop_geo[1], g_backdrop_geo[2], g_backdrop_geo[3]);
+            bd.SetFixedSize2(screen_w, screen_h);
+            bd.OnMousePressEvent(onBackdropClick);
+            bd.OnMoveEvent(onBackdropMove);
+            g_backdrop = bd;
+            bd.Show();
+        }
+
         var window = QWidget.New2();
         window.SetWindowTitle("zenkai");
-
-        const wt = qt.qnamespace_enums.WindowType;
         window.SetWindowFlags(
             wt.Tool |
                 wt.FramelessWindowHint |
@@ -89,15 +166,14 @@ pub const Window = struct {
         window.SetMinimumSize2(win_w, win_h);
         window.SetMaximumSize2(win_w, win_h);
 
-        const screen = window.Screen();
-        const screen_rect = screen.Geometry();
         window.SetGeometry(
-            @divTrunc(screen_rect.Width() - win_w, 2),
-            @divTrunc(screen_rect.Height() - win_h, 2),
+            @divTrunc(screen_w - win_w, 2),
+            @divTrunc(screen_h - win_h, 2),
             win_w,
             win_h,
         );
 
+        const wa = qt.qnamespace_enums.WidgetAttribute;
         const fade_h: i32 = 40;
         var fade = QWidget.New(window);
         fade.SetObjectName("listFade");
@@ -108,16 +184,23 @@ pub const Window = struct {
             fade.SetGeometry(vis.layout_margin, win_h - vis.layout_margin - 28 - fade_h, win_w - 2 * vis.layout_margin, fade_h);
         }
         fade.Raise();
-        fade.SetAttribute2(qt.qnamespace_enums.WidgetAttribute.WA_TransparentForMouseEvents, true);
+        fade.SetAttribute2(wa.WA_TransparentForMouseEvents, true);
 
         g_window = self;
+        g_close_on_focus_out = vis.close_on_focus_out;
+        g_mouse_left_at = nanoTimestamp();
+        g_blur_timer = qt.QTimer.New();
+        g_blur_timer.OnTimeout(onBlurTimerTimeout);
 
         window.OnCloseEvent(onWindowClose);
+        window.OnLeaveEvent(onLeaveWidget);
+        app.OnApplicationStateChanged(onAppStateChanged);
         Keyboard.setup(window, &self.list);
     }
 
     pub fn show(self: *Window) void {
         self.widget.Show();
+        self.widget.Raise();
     }
 
     pub fn exec() void {
@@ -125,6 +208,9 @@ pub const Window = struct {
     }
 
     pub fn deinit(self: *Window) void {
+        g_blur_timer.Stop();
+        g_blur_timer.Delete();
+        closeBackdrop();
         self.search_bar.deinit();
         self.list.deinit();
         if (self.bottom_bar) |*bar| bar.deinit();


### PR DESCRIPTION
## Issue Link:
#17 

## Fixes:
- Added a new: `close-on-focus-out` flag that defaults to false, if set it will close the launcher when it loses focus so e.g if the user clicks outside
- Added `show-backdrop` which will throw an invisible backdrop behind the launcher, clicking on the backdrop will close the launcher.

## Reasoning
Right now on hyprland with focus on mouseover set to true, the launcher will immediately close if the user moves their mouse anywhere outside the launcher. So for those users like myself that have hyprland with that option turned on we simply run the launcher as is and explicitly close it by hitting `esc` on the keyboard

Everyone else can set `--close-on-focus-out` which will close the launcher when the user clicks outside the launcher.

Alternatively if people on hyprland with focus on mouseover set to true want the same functionality we can use `--show-backdrop` and explicitly set window rules for the backdrop to not apply any blur or opacity changes, that way we get an invisible backdrop that will close the launcher when clicked outside the launcher.

I feel like I could have worded all of this a lot better, but it will have to do.