### PR TITLE
fix: skip tokens that are not required in launchers like %u

### DIFF
--- a/src/core/desktop_loader.zig
+++ b/src/core/desktop_loader.zig
@@ -31,7 +31,7 @@ fn parseAndStoreActions(allocator: std.mem.Allocator, da: *const de.DesktopApp, 
         for (parsed) |action| {
             try actions_out.append(allocator, .{
                 .name = try allocator.dupe(u8, action.name),
-                .exec = try allocator.dupe(u8, action.exec),
+                .exec = try de.DesktopEntry.expandExecString(action.exec, da, allocator),
                 .icon = if (action.icon) |ic| try allocator.dupe(u8, ic) else try allocator.dupe(u8, if (da.icon) |ic2| ic2 else ""),
             });
         }
@@ -48,9 +48,13 @@ pub fn freeListItemActions(allocator: std.mem.Allocator, actions: []const ui.Lis
 }
 
 fn makeListItem(allocator: std.mem.Allocator, da: *const de.DesktopApp, actions: []const ui.ListItemAction, app_idx: usize) !ui.ListItem {
+    const cmd = if (da.exec) |e|
+        try de.DesktopEntry.expandExecString(e, da, allocator)
+    else
+        try allocator.dupe(u8, "");
     return .{
         .icon = try allocator.dupe(u8, if (da.icon) |ic| ic else ""),
-        .cmd = try allocator.dupe(u8, if (da.exec) |e| e else ""),
+        .cmd = cmd,
         .name = try allocator.dupe(u8, da.name),
         .actions = actions,
         .desktop_app_idx = app_idx,

--- a/src/core/desktopapp.zig
+++ b/src/core/desktopapp.zig
@@ -43,7 +43,10 @@ pub const DesktopEntry = struct {
 
     pub fn expandExec(self: *const DesktopEntry, allocator: std.mem.Allocator) ![]const u8 {
         const exec = self.exec orelse return error.NoExec;
+        return expandExecString(exec, self, allocator);
+    }
 
+    pub fn expandExecString(exec: []const u8, entry: *const DesktopEntry, allocator: std.mem.Allocator) ![]const u8 {
         var buf: std.ArrayList(u8) = .empty;
         errdefer buf.deinit(allocator);
 
@@ -54,14 +57,14 @@ pub const DesktopEntry = struct {
                     '%' => try buf.append(allocator, '%'),
                     'f', 'F', 'u', 'U' => {},
                     'i' => {
-                        if (self.icon) |icon| {
+                        if (entry.icon) |icon| {
                             try buf.appendSlice(allocator, "--icon ");
                             try shellQuote(allocator, &buf, icon);
                         }
                     },
-                    'c' => try shellQuote(allocator, &buf, self.name),
+                    'c' => try shellQuote(allocator, &buf, entry.name),
                     'k' => {
-                        if (self.file_path) |fp| try shellQuote(allocator, &buf, fp);
+                        if (entry.file_path) |fp| try shellQuote(allocator, &buf, fp);
                     },
                     else => {
                         try buf.append(allocator, '%');


### PR DESCRIPTION
## Issue Link:
#21 

## Issue Description:
`%u, %U, %f, %F` are not needed in most launchers.
All of these can later be supported via plugin and added in explicitly via the plugin 