### PR TITLE
fix: implemented list wrapping

### DIFF
--- a/src/ui/keyboard.zig
+++ b/src/ui/keyboard.zig
@@ -7,14 +7,23 @@ const QShortcut = qt.QShortcut;
 const QKeySequence = qt.QKeySequence;
 const QWidget = qt.QWidget;
 const QApp = qt.QApplication;
+const QLineEdit = qt.QLineEdit;
 
 var L: *List = undefined;
+var search_widget: QLineEdit = undefined;
 
 fn currentRow() ?i32 {
     var idx = L.view.CurrentIndex();
     defer idx.Delete();
     if (!idx.IsValid()) return null;
     return idx.Row();
+}
+
+fn focusSearch() void {
+    var invalid = List.invalidIndex();
+    defer invalid.Delete();
+    L.view.SetCurrentIndex(invalid);
+    search_widget.SetFocus();
 }
 
 fn onEnter(_: QShortcut) callconv(.c) void {
@@ -26,7 +35,11 @@ fn onUp(_: QShortcut) callconv(.c) void {
         if (L.indices.items.len > 0) L.selectRow(@intCast(L.indices.items.len - 1));
         return;
     };
-    if (row > 0) L.selectRow(row - 1);
+    if (row > 0) {
+        L.selectRow(row - 1);
+    } else {
+        focusSearch();
+    }
 }
 
 fn onDown(_: QShortcut) callconv(.c) void {
@@ -34,7 +47,11 @@ fn onDown(_: QShortcut) callconv(.c) void {
         if (L.indices.items.len > 0) L.selectRow(0);
         return;
     };
-    if (row < L.indices.items.len - 1) L.selectRow(row + 1);
+    if (row < L.indices.items.len - 1) {
+        L.selectRow(row + 1);
+    } else {
+        focusSearch();
+    }
 }
 
 fn bind(window: QWidget, key: []const u8, handler: *const fn (QShortcut) callconv(.c) void) void {
@@ -62,8 +79,9 @@ fn makeActionHandler(comptime n: usize) *const fn (QShortcut) callconv(.c) void 
 }
 
 pub const Keyboard = struct {
-    pub fn setup(window: QWidget, list: *List) void {
+    pub fn setup(window: QWidget, list: *List, search: QLineEdit) void {
         L = list;
+        search_widget = search;
         bind(window, "Return", onEnter);
         bind(window, "Up", onUp);
         bind(window, "Down", onDown);

--- a/src/ui/window.zig
+++ b/src/ui/window.zig
@@ -195,7 +195,7 @@ pub const Window = struct {
         window.OnCloseEvent(onWindowClose);
         window.OnLeaveEvent(onLeaveWidget);
         app.OnApplicationStateChanged(onAppStateChanged);
-        Keyboard.setup(window, &self.list);
+        Keyboard.setup(window, &self.list, self.search_bar.widget);
     }
 
     pub fn show(self: *Window) void {


### PR DESCRIPTION
The commit looks good. The reasoning could be improved to cover both directions:
## Fixes
- Keyboard navigation wraps fully between search input and results list

## Reasoning
When pressing Up at the top of the results list, focus moves to the search
input and clears the list selection so the next Down press starts at row 0.
When pressing Down at the bottom of the results list, the same focusing
behavior applies. From the search input, Up/Down jump to the last/first
item respectively. This creates full wraparound navigation between the
search bar and the list, matching the behavior of common launchers.
Previously, Up at row 0 and Down at the last row were no-ops, trapping
keyboard focus at list boundaries.