### PR TITLE
fix: simple contrast fix

### DIFF
--- a/src/styles/minimal.qss
+++ b/src/styles/minimal.qss
@@ -21,7 +21,8 @@ QWidget {
 }
 
 #appList::item:selected {
-    background: #222222;
+    background: #3a3a3a;
+    color: #ffffff;
 }
 
 #listFade {


### PR DESCRIPTION
## Fixes
- Increased selected item contrast in the minimal theme

## Reasoning
The `#appList::item:selected` block only set `background: #222222` with no
explicit color property. On Qt Fusion style, the system palette's
`HighlightedText` color was used instead of inheriting from `QWidget`,
making text blend into the selection background. Lightened background
to `#3a3a3a` (visible against #000000 list bg) and added explicit
color: `#ffffff` for guaranteed readable text.