### PR TITLE
feature: clipboard, url handler support and no return enum

### DIFF
--- a/external/plugins/calculator/main.lua
+++ b/external/plugins/calculator/main.lua
@@ -26,7 +26,7 @@ function on_query(query)
         if rounded then
             display = tostring(rounded)
         end
-        api.add_result(display, expr .. " =", "accessories-calculator")
+        api.add_result(display, expr .. " =", "accessories-calculator", "NoReturn")
     end
 end
 

--- a/src/args/args.zig
+++ b/src/args/args.zig
@@ -22,6 +22,8 @@ pub const help =
     \\  --close-on-focus-out     Close the launcher when it loses focus
     \\  --no-close-on-focus-out  Keep the launcher open when it loses focus
     \\  --show-backdrop           Show a backdrop to detect clicks outside the launcher
+    \\  --clipboard=CMD           Clipboard command for ExecCmd plugin results (e.g. xclip -selection c)
+    \\  --url-handler=CMD         URL handler for plugin open_url results (e.g. xdg-open, firefox)
     \\  --help, -h                Show this help and exit
 ;
 
@@ -40,6 +42,8 @@ pub const Config = struct {
     show_backdrop: bool,
     window_width: ?i32,
     window_height: ?i32,
+    clipboard: ?[]const u8,
+    url_handler: ?[]const u8,
 };
 
 pub const MenuEntry = struct {
@@ -110,6 +114,8 @@ pub fn parse(args: [][:0]u8) Config {
         .show_backdrop = false,
         .window_width = null,
         .window_height = null,
+        .clipboard = null,
+        .url_handler = null,
     };
 
     for (args) |arg_slice| {
@@ -150,6 +156,12 @@ pub fn parse(args: [][:0]u8) Config {
             cfg.close_on_focus_out = false;
         } else if (std.mem.eql(u8, arg, "--show-backdrop")) {
             cfg.show_backdrop = true;
+        } else if (std.mem.startsWith(u8, arg, "--clipboard=")) {
+            const val = arg["--clipboard=".len..];
+            cfg.clipboard = if (val.len > 0) val else null;
+        } else if (std.mem.startsWith(u8, arg, "--url-handler=")) {
+            const val = arg["--url-handler=".len..];
+            cfg.url_handler = if (val.len > 0) val else null;
         } else if (std.mem.eql(u8, arg, "--list-themes")) {
             cfg.list_themes = true;
         }

--- a/src/config/config.toml
+++ b/src/config/config.toml
@@ -19,6 +19,12 @@ close_on_focus_out = false
 # Show a transparent backdrop covering the full screen to catch clicks outside
 show_backdrop = false
 
+# Clipboard command for plugin ExecCmd results (e.g. xclip -selection c)
+clipboard = ""
+
+# URL handler command for plugin open_url results (e.g. xdg-open, firefox)
+url_handler = "xdg-open"
+
 # -- Bottom bar (action buttons bar) ------------------------------------------
 bottom_bar_margin_top = 4
 bottom_bar_margin_bottom = 4

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -12,13 +12,28 @@ pub const VisualConfig = struct {
     icon_size: i32 = 32,
     close_on_focus_out: bool = false,
     show_backdrop: bool = false,
+    clipboard: ?[]const u8 = null,
+    url_handler: ?[]const u8 = null,
 
-    pub fn applyOverrides(self: *VisualConfig, cfg: anytype) void {
+    pub fn deinit(self: *VisualConfig, allocator: std.mem.Allocator) void {
+        if (self.clipboard) |v| allocator.free(v);
+        if (self.url_handler) |v| allocator.free(v);
+    }
+
+    pub fn applyOverrides(self: *VisualConfig, allocator: std.mem.Allocator, cfg: anytype) void {
         if (cfg.window_width) |v| self.window_width = v;
         if (cfg.window_height) |v| self.window_height = v;
         if (cfg.icon_size) |v| self.icon_size = v;
         if (cfg.close_on_focus_out) |v| self.close_on_focus_out = v;
         if (cfg.show_backdrop) self.show_backdrop = true;
+        if (cfg.clipboard) |v| {
+            if (self.clipboard) |old| allocator.free(old);
+            self.clipboard = if (v.len > 0) allocator.dupe(u8, v) catch null else null;
+        }
+        if (cfg.url_handler) |v| {
+            if (self.url_handler) |old| allocator.free(old);
+            self.url_handler = if (v.len > 0) allocator.dupe(u8, v) catch null else null;
+        }
     }
 };
 
@@ -89,6 +104,12 @@ pub fn loadConfig(allocator: std.mem.Allocator, config_path: []const u8) !Visual
         if (std.mem.eql(u8, key, "icon_size")) cfg.icon_size = parseInt(val) catch continue;
         if (std.mem.eql(u8, key, "close_on_focus_out")) cfg.close_on_focus_out = std.mem.eql(u8, val, "true");
         if (std.mem.eql(u8, key, "show_backdrop")) cfg.show_backdrop = std.mem.eql(u8, val, "true");
+        if (std.mem.eql(u8, key, "clipboard")) {
+            if (val.len > 0) cfg.clipboard = allocator.dupe(u8, val) catch null;
+        }
+        if (std.mem.eql(u8, key, "url_handler")) {
+            if (val.len > 0) cfg.url_handler = allocator.dupe(u8, val) catch null;
+        }
     }
 
     return cfg;

--- a/src/core/bootstrap.zig
+++ b/src/core/bootstrap.zig
@@ -19,6 +19,7 @@ pub const Context = struct {
     start_ns: u64,
 
     pub fn deinit(self: *Context) void {
+        self.visual.deinit(self.allocator);
         self.app.Delete();
         qt.deinit(self.allocator, self.argv);
     }
@@ -35,7 +36,7 @@ pub fn init(allocator: std.mem.Allocator, raw_args: anytype) !Context {
     defer allocator.free(config_path);
 
     var visual = try config.loadConfig(allocator, config_path);
-    visual.applyOverrides(cfg);
+    visual.applyOverrides(allocator, cfg);
 
     const theme_resolved = theme.resolve(allocator, cfg.theme);
     defer if (theme_resolved.allocation) |m| allocator.free(m);

--- a/src/main.zig
+++ b/src/main.zig
@@ -40,6 +40,13 @@ pub fn main(init: std.process.Init) !void {
     var pm = plugins.setup(init.gpa);
     defer pm.deinit();
 
+    if (ctx.visual.clipboard) |clip| {
+        pm.clipboard_cmd = init.gpa.dupe(u8, clip) catch null;
+    }
+    if (ctx.visual.url_handler) |handler| {
+        pm.url_handler = init.gpa.dupe(u8, handler) catch null;
+    }
+
     const use_menus = menu_entries.len > 0;
     const items = if (use_menus) blk: {
         var list_items = try std.ArrayList(ui.ListItem).initCapacity(init.gpa, menu_entries.len);

--- a/src/plugins/plugins.zig
+++ b/src/plugins/plugins.zig
@@ -9,6 +9,7 @@ pub const Manifest = types.Manifest;
 pub const Hook = types.Hook;
 pub const Plugin = types.Plugin;
 pub const PluginResult = types.PluginResult;
+pub const ResultType = types.ResultType;
 pub const setupSandbox = sandbox.setupSandbox;
 pub const callPluginMethod = sandbox.callPluginMethod;
 
@@ -22,7 +23,13 @@ fn apiAddResult(L: *lua.lua_State) callconv(.c) c_int {
     const title = if (lua.lua_tostring(L, 1)) |s| std.mem.sliceTo(s, 0) else "";
     const subtitle = if (lua.lua_tostring(L, 2)) |s| std.mem.sliceTo(s, 0) else "";
     const icon = if (lua.lua_tostring(L, 3)) |s| std.mem.sliceTo(s, 0) else "";
+    const result_type_str = if (lua.lua_tostring(L, 4)) |s| std.mem.sliceTo(s, 0) else "";
     const allocator = g_active_manager.allocator;
+
+    const result_type: types.ResultType = if (std.mem.eql(u8, result_type_str, "NoReturn"))
+        .NoReturn
+    else
+        .ExecCmd;
 
     var tracked = struct {
         title: ?[]u8 = null,
@@ -55,6 +62,7 @@ fn apiAddResult(L: *lua.lua_State) callconv(.c) c_int {
         .title = tracked.title.?,
         .subtitle = tracked.subtitle.?,
         .icon = tracked.icon.?,
+        .result_type = result_type,
     }) catch |err| {
         utils.log.info("plugin add_result OOM (append): {}", .{err});
         return 0;
@@ -127,11 +135,15 @@ pub fn setup(allocator: std.mem.Allocator) PluginManager {
 pub const PluginManager = struct {
     allocator: std.mem.Allocator,
     plugins: std.ArrayList(Plugin),
+    clipboard_cmd: ?[]const u8,
+    url_handler: ?[]const u8,
 
     pub fn init(allocator: std.mem.Allocator) PluginManager {
         return .{
             .allocator = allocator,
             .plugins = std.ArrayList(Plugin).empty,
+            .clipboard_cmd = null,
+            .url_handler = null,
         };
     }
 
@@ -146,6 +158,8 @@ pub const PluginManager = struct {
             if (plugin.manifest.author) |a| self.allocator.free(a);
         }
         self.plugins.deinit(self.allocator);
+        if (self.clipboard_cmd) |c| self.allocator.free(c);
+        if (self.url_handler) |h| self.allocator.free(h);
     }
 
     fn scanPluginDir(self: *PluginManager, io: std.Io, dir_path: []const u8) void {
@@ -305,35 +319,82 @@ pub const PluginManager = struct {
         }
     }
 
-    pub fn handleSelect(self: *PluginManager, plugin_index: usize, result_identifier: usize) void {
-        const plugin = &self.plugins.items[plugin_index];
-        if (!plugin.hooks.contains(.on_open)) return;
+    pub fn handleSelect(self: *PluginManager, result: *const PluginResult) void {
+        switch (result.result_type) {
+            .NoReturn => return,
+            .ExecCmd => {},
+        }
 
-        _ = lua.lua_getglobal(plugin.state, "on_open");
-        lua.lua_pushinteger(plugin.state, @as(i64, @intCast(result_identifier)));
-        sandbox.callPluginMethod(plugin, 1, "open error");
+        const plugin = &self.plugins.items[result.plugin_index];
+        if (plugin.hooks.contains(.on_open)) {
+            _ = lua.lua_getglobal(plugin.state, "on_open");
+            lua.lua_pushinteger(plugin.state, @as(i64, @intCast(result.id)));
+            sandbox.callPluginMethod(plugin, 1, "open error");
+        }
 
         if (g_pending_open_url) |url| {
-            const url_z = self.allocator.dupeZ(u8, url) catch {
-                self.allocator.free(url);
-                g_pending_open_url = null;
-                return;
-            };
-            defer self.allocator.free(url_z);
-            self.allocator.free(url);
+            defer self.allocator.free(url);
             g_pending_open_url = null;
 
-            const xdg_open = @as([*:0]const u8, "xdg-open");
-            const argv = [_:null]?[*:0]u8{
-                @constCast(xdg_open),
-                url_z,
-                null,
-            };
-            const pid = std.os.linux.fork();
-            if (std.os.linux.errno(pid) == .SUCCESS and pid == 0) {
-                _ = std.os.linux.execve("/usr/bin/xdg-open", &argv, utils.environ);
-                _ = std.os.linux.execve("/bin/xdg-open", &argv, utils.environ);
-                std.os.linux.exit(1);
+            if (url.len > 1023) return;
+
+            if (self.clipboard_cmd) |clip_cmd| {
+                var pipefd: [2]i32 = undefined;
+                if (std.os.linux.pipe(&pipefd) != 0) return;
+
+                const pid = std.os.linux.fork();
+                if (std.os.linux.errno(pid) != .SUCCESS) {
+                    _ = std.os.linux.close(pipefd[0]);
+                    _ = std.os.linux.close(pipefd[1]);
+                    return;
+                }
+
+                if (pid == 0) {
+                    _ = std.os.linux.close(pipefd[1]);
+                    _ = std.os.linux.dup2(pipefd[0], 0);
+                    if (pipefd[0] != 0) _ = std.os.linux.close(pipefd[0]);
+
+                    var buf: [1024:0]u8 = undefined;
+                    if (clip_cmd.len >= buf.len) std.process.exit(1);
+                    @memcpy(buf[0..clip_cmd.len], clip_cmd);
+                    buf[clip_cmd.len] = 0;
+                    const sh = @as([*:0]const u8, "sh");
+                    const c = @as([*:0]const u8, "-c");
+                    const argv = [_:null]?[*:0]u8{
+                        @constCast(sh),
+                        @constCast(c),
+                        @as([*:0]u8, @ptrCast(&buf)),
+                        null,
+                    };
+                    _ = std.os.linux.execve("/bin/sh", &argv, utils.environ);
+                    std.os.linux.exit(1);
+                }
+
+                _ = std.os.linux.close(pipefd[0]);
+                _ = std.os.linux.write(pipefd[1], url.ptr, url.len);
+                _ = std.os.linux.close(pipefd[1]);
+            } else {
+                const handler = self.url_handler orelse "xdg-open";
+                var buf: [1024:0]u8 = undefined;
+                const total = handler.len + 1 + url.len;
+                if (total >= buf.len) return;
+                @memcpy(buf[0..handler.len], handler);
+                buf[handler.len] = ' ';
+                @memcpy(buf[handler.len + 1 ..][0..url.len], url);
+                buf[total] = 0;
+                const sh = @as([*:0]const u8, "sh");
+                const c = @as([*:0]const u8, "-c");
+                const argv = [_:null]?[*:0]u8{
+                    @constCast(sh),
+                    @constCast(c),
+                    @as([*:0]u8, @ptrCast(&buf)),
+                    null,
+                };
+                const pid = std.os.linux.fork();
+                if (std.os.linux.errno(pid) == .SUCCESS and pid == 0) {
+                    _ = std.os.linux.execve("/bin/sh", &argv, utils.environ);
+                    std.os.linux.exit(1);
+                }
             }
         }
     }

--- a/src/plugins/types.zig
+++ b/src/plugins/types.zig
@@ -28,10 +28,16 @@ pub const Plugin = struct {
     hooks: std.EnumSet(Hook),
 };
 
+pub const ResultType = enum {
+    NoReturn,
+    ExecCmd,
+};
+
 pub const PluginResult = struct {
     plugin_index: usize,
     id: usize,
     title: []const u8,
     subtitle: []const u8,
     icon: []const u8,
+    result_type: ResultType = .ExecCmd,
 };

--- a/src/ui/list.zig
+++ b/src/ui/list.zig
@@ -421,7 +421,10 @@ pub const List = struct {
             },
             .plugin => |plugin_result_index| {
                 const plugin_result = &self.plugin_results.items[plugin_result_index];
-                if (self.plugin_manager) |plugin_manager| plugin_manager.handleSelect(plugin_result.plugin_index, plugin_result.id);
+                if (self.plugin_manager) |plugin_manager| {
+                    plugin_manager.handleSelect(plugin_result);
+                    if (plugin_result.result_type == .NoReturn) return;
+                }
             },
         }
         QApp.Quit();


### PR DESCRIPTION
## Fixes
- **Plugin NoReturn result type**: Added `ResultType` enum (`NoReturn` / `ExecCmd`) so plugins can mark results that should not close the launcher on selection (e.g. calculator showing a computed value)
- **Plugin clipboard support**: Plugin `api.open_url()` can pipe content into a clipboard command (`xclip`, `wl-clipboard`, etc.) instead of opening a URL in the browser
- **URL handler config**: `url_handler` option (config file + `--url-handler` CLI flag) replaces the hardcoded `xdg-open` users can set `firefox`, `google-chrome`, or any custom handler
- **Calculator plugin uses NoReturn**: Selecting a calculator result no longer quits the launcher
## Reasoning
Plugin results had no way to control launcher behavior on selection every selection quit the launcher. The `ResultType` enum lets plugins signal intent: `NoReturn` keeps the launcher open, `ExecCmd` proceeds with the existing `on_open` workflow.
The old `xdg-open` was hardcoded in the URL handling path and was also the only output path. Adding `clipboard_cmd` (via `--clipboard` CLI or `clipboard` config) gives plugins an alternative: pipe URLs into a clipboard tool. The `url_handler` config replaces the `xdg-open` hardcode so users can choose their own browser or URL handler. Both settings are available in `config.toml` and overridable via CLI flags.