### PR TITLE
feature: frequency store to surface frequently used apps

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -120,6 +120,13 @@ pub fn build(b: *std.Build) void {
         .imports = &.{.{ .name = "utils", .module = utils_module }},
     });
 
+    const frequency_module = b.addModule("core_freq", .{
+        .root_source_file = b.path("src/core/frequency.zig"),
+        .imports = &.{
+            .{ .name = "utils", .module = utils_module },
+        },
+    });
+
     const plugins_module = b.addModule("plugins", .{
         .root_source_file = b.path("src/plugins/plugins.zig"),
         .imports = &.{
@@ -143,6 +150,7 @@ pub fn build(b: *std.Build) void {
     exe.root_module.addImport("config", config_module);
     exe.root_module.addImport("lua_capi", lua_capi_module);
     exe.root_module.addImport("plugins", plugins_module);
+    exe.root_module.addImport("core_freq", frequency_module);
     if (osx_module) |mod| exe.root_module.addImport("osx", mod);
     b.installArtifact(exe);
 

--- a/src/config/config.zig
+++ b/src/config/config.zig
@@ -37,7 +37,7 @@ pub const VisualConfig = struct {
     }
 };
 
-fn configDir(allocator: std.mem.Allocator) ![]u8 {
+pub fn configDir(allocator: std.mem.Allocator) ![]u8 {
     if (std.c.getenv("XDG_CONFIG_HOME")) |xdg| {
         const dir = std.mem.sliceTo(xdg, 0);
         return try std.fs.path.join(allocator, &.{ dir, "zenkai" });

--- a/src/core/frequency.zig
+++ b/src/core/frequency.zig
@@ -1,0 +1,99 @@
+const std = @import("std");
+const log = @import("utils").log;
+const fsutils = @import("utils").fsutils;
+
+pub const Row = struct {
+    name: []const u8,
+    score: u32,
+};
+
+pub const file_name = "frequency.dat";
+
+pub const FrequencyStore = struct {
+    allocator: std.mem.Allocator,
+    scores: std.StringHashMap(u32),
+    dirty: bool,
+
+    pub fn init(allocator: std.mem.Allocator) FrequencyStore {
+        return .{
+            .allocator = allocator,
+            .scores = std.StringHashMap(u32).init(allocator),
+            .dirty = false,
+        };
+    }
+
+    pub fn deinit(self: *FrequencyStore) void {
+        var it = self.scores.iterator();
+        while (it.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+        }
+        self.scores.deinit();
+    }
+
+    pub fn load(self: *FrequencyStore, dir_path: []const u8) void {
+        const path = std.fs.path.join(self.allocator, &.{ dir_path, file_name }) catch return;
+        defer self.allocator.free(path);
+
+        const content = fsutils.readFile(self.allocator, path, 128 * 1024) catch return;
+        defer self.allocator.free(content);
+
+        var lines = std.mem.splitScalar(u8, content, '\n');
+        while (lines.next()) |line| {
+            const trimmed = std.mem.trim(u8, line, " \t\r");
+            if (trimmed.len == 0) continue;
+            const eq = std.mem.indexOfScalar(u8, trimmed, '=') orelse continue;
+            const key = trimmed[0..eq];
+            const val = std.fmt.parseInt(u32, trimmed[eq + 1 ..], 10) catch continue;
+            if (key.len > 0) {
+                const key_duped = self.allocator.dupe(u8, key) catch continue;
+                self.scores.put(key_duped, val) catch {
+                    self.allocator.free(key_duped);
+                };
+            }
+        }
+    }
+
+    pub fn save(self: *FrequencyStore, dir_path: []const u8) void {
+        if (!self.dirty) return;
+        const path = std.fs.path.join(self.allocator, &.{ dir_path, file_name }) catch return;
+        defer self.allocator.free(path);
+
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(self.allocator);
+        var it = self.scores.iterator();
+        while (it.next()) |entry| {
+            const line = std.fmt.allocPrint(self.allocator, "{s}={d}\n", .{ entry.key_ptr.*, entry.value_ptr.* }) catch continue;
+            defer self.allocator.free(line);
+            buf.appendSlice(self.allocator, line) catch return;
+        }
+
+        const io = std.Io.Threaded.io(std.Io.Threaded.global_single_threaded);
+        const cwd = std.Io.Dir.cwd();
+        var file = std.Io.Dir.createFile(cwd, io, path, .{}) catch {
+            log.info("failed to save frequency data", .{});
+            return;
+        };
+        defer std.Io.File.close(file, io);
+        file.writeStreamingAll(io, buf.items) catch {
+            log.info("failed to write frequency data", .{});
+        };
+        self.dirty = false;
+    }
+
+    pub fn increment(self: *FrequencyStore, key: []const u8) void {
+        if (self.scores.getPtr(key)) |count| {
+            count.* += 1;
+            self.dirty = true;
+            return;
+        }
+        const key_duped = self.allocator.dupe(u8, key) catch return;
+        self.scores.put(key_duped, 1) catch {
+            self.allocator.free(key_duped);
+        };
+        self.dirty = true;
+    }
+
+    pub fn getScore(self: *FrequencyStore, key: []const u8) u32 {
+        return self.scores.get(key) orelse 0;
+    }
+};

--- a/src/main.zig
+++ b/src/main.zig
@@ -9,6 +9,8 @@ const args = @import("args/args.zig");
 const theme = @import("theme/theme.zig");
 const plugins = @import("plugins");
 const styles_watcher = @import("ui/styles_watcher.zig");
+const config = @import("config");
+const core_freq = @import("core_freq");
 
 extern fn freopen([*:0]const u8, [*:0]const u8, *anyopaque) ?*anyopaque;
 extern var __stderrp: *anyopaque;
@@ -18,6 +20,7 @@ pub fn main(init: std.process.Init) !void {
         _ = freopen("/dev/null", "w", __stderrp);
     }
 
+    var debug_freq = false;
     {
         var args_iter = init.minimal.args.iterate();
         while (args_iter.next()) |arg| {
@@ -27,6 +30,9 @@ pub fn main(init: std.process.Init) !void {
                     std.debug.print("  {s:<26} {s}\n", .{ entry.name, entry.desc });
                 }
                 std.process.exit(0);
+            }
+            if (std.mem.eql(u8, arg, "--debug-freq")) {
+                debug_freq = true;
             }
         }
     }
@@ -100,6 +106,28 @@ pub fn main(init: std.process.Init) !void {
     window.list.plugin_manager = &pm;
     defer window.deinit();
 
+    var freq_store = core_freq.FrequencyStore.init(init.gpa);
+    defer freq_store.deinit();
+    var cfg_dir_opt: ?[]u8 = null;
+    if (config.configDir(init.gpa)) |cfg_dir| {
+        freq_store.load(cfg_dir);
+        window.list.frequency_store = &freq_store;
+        window.list.setFilter("");
+        cfg_dir_opt = cfg_dir;
+    } else |_| {}
+    defer {
+        if (cfg_dir_opt) |cfg_dir| init.gpa.free(cfg_dir);
+    }
+
+    if (debug_freq) {
+        std.debug.print("Frequency store contents:\n", .{});
+        var it = freq_store.scores.iterator();
+        while (it.next()) |entry| {
+            std.debug.print("  {s} = {d}\n", .{ entry.key_ptr.*, entry.value_ptr.* });
+        }
+        std.debug.print("  (dirty: {any})\n", .{freq_store.dirty});
+    }
+
     if (ctx.cfg.benchmark_all) debug.mark("show window");
     window.show();
 
@@ -111,4 +139,6 @@ pub fn main(init: std.process.Init) !void {
 
     if (ctx.cfg.start_timer and ctx.cfg.theme_reloader) styles_watcher.start(init.gpa);
     ui.Window.exec();
+
+    if (cfg_dir_opt) |cfg_dir| freq_store.save(cfg_dir);
 }

--- a/src/ui/list.zig
+++ b/src/ui/list.zig
@@ -1,8 +1,9 @@
 const std = @import("std");
 const qt = @import("libqt6zig");
-const de = @import("desktopapp");
-const plugins = @import("plugins");
 const utils = @import("utils");
+const plugins = @import("plugins");
+const de = @import("desktopapp");
+const freq = @import("core_freq");
 const log = @import("utils").log;
 
 const QListView = qt.QListView;
@@ -237,6 +238,29 @@ fn onData(
     return QVariant.New();
 }
 
+const FreqSortContext = struct {
+    store: *freq.FrequencyStore,
+    source: *const DataSource,
+};
+
+fn freqLessThan(ctx: FreqSortContext, a: IndexEntry, b: IndexEntry) bool {
+    const key_a = switch (a) {
+        .item => |i| switch (ctx.source.*) {
+            .desktop_apps => |apps| apps[i].name,
+            .items => |items| items[i].name,
+        },
+        .plugin => return false,
+    };
+    const key_b = switch (b) {
+        .item => |i| switch (ctx.source.*) {
+            .desktop_apps => |apps| apps[i].name,
+            .items => |items| items[i].name,
+        },
+        .plugin => return true,
+    };
+    return ctx.store.getScore(key_a) > ctx.store.getScore(key_b);
+}
+
 pub const List = struct {
     allocator: std.mem.Allocator,
     view: QListView,
@@ -245,6 +269,7 @@ pub const List = struct {
     indices: std.ArrayList(IndexEntry),
     plugin_results: std.ArrayList(plugins.PluginResult),
     plugin_manager: ?*plugins.PluginManager,
+    frequency_store: ?*freq.FrequencyStore,
 
     pub fn init(allocator: std.mem.Allocator, apps: []const de.DesktopApp, icon_size: i32, plugin_manager: ?*plugins.PluginManager) List {
         g_icon_size = icon_size;
@@ -284,6 +309,7 @@ pub const List = struct {
             .indices = std.ArrayList(IndexEntry).empty,
             .plugin_results = std.ArrayList(plugins.PluginResult).empty,
             .plugin_manager = plugin_manager,
+            .frequency_store = null,
         };
         g_list = &result;
         view.SetModel(model);
@@ -362,12 +388,20 @@ pub const List = struct {
             }
         }
 
-        if (self.plugin_manager) |plugin_manager| {
-            if (text.len > 0) {
-                plugin_manager.queryAll(text, &self.plugin_results);
-                for (0..self.plugin_results.items.len) |plugin_index| {
-                    self.indices.append(self.allocator, IndexEntry{ .plugin = plugin_index }) catch |err| log.info("OOM in setFilter: {}", .{err});
-                }
+        const plugin_count = if (self.plugin_manager != null and text.len > 0) blk: {
+            const pm = self.plugin_manager.?;
+            pm.queryAll(text, &self.plugin_results);
+            for (0..self.plugin_results.items.len) |plugin_index| {
+                self.indices.append(self.allocator, IndexEntry{ .plugin = plugin_index }) catch |err| log.info("OOM in setFilter: {}", .{err});
+            }
+            break :blk self.plugin_results.items.len;
+        } else 0;
+
+        if (self.frequency_store) |store| {
+            const item_count = self.indices.items.len - plugin_count;
+            if (item_count > 1) {
+                const ctx = FreqSortContext{ .store = store, .source = &self.source };
+                std.sort.insertion(IndexEntry, self.indices.items[0..item_count], ctx, freqLessThan);
             }
         }
 
@@ -407,6 +441,9 @@ pub const List = struct {
 
         switch (self.indices.items[row]) {
             .item => |item_idx| {
+                if (self.frequency_store) |store| {
+                    store.increment(self.sourceName(item_idx));
+                }
                 switch (self.source) {
                     .desktop_apps => |apps| {
                         const app = &apps[item_idx];


### PR DESCRIPTION
## Fixes
Previously the launcher would show apps in a random order, which was fairly annoying and required a lot of searching. This PR will score most frequently used apps and place them at the top of the launcher.

## Reasoning
Adds a frequency store that tracks app launch counts and surfaces frequently used apps above less used ones. The store persists to `~/.config/zenkai/frequency.dat` so frequency data carries across sessions.
- New `core_freq` module with `FrequencyStore` (load, save, increment, getScore)
- List sorts matched items by frequency in `setFilter` before display
- `launchSelected` increments the counter on each launch
- Save happens after `exec()` returns, wired via `cfg_dir_opt`
- `--debug-freq` flag to inspect stored scores at startup
- `Row` type exposed for external iteration of frequency entries
- `file_name` constant exposed for external path construction