### PR TITLE
feature: performance improvements implemented

### DIFF
--- a/src/core/dapp_parser.zig
+++ b/src/core/dapp_parser.zig
@@ -144,12 +144,11 @@ pub const LineIterator = struct {
 
         const start = self.index;
 
-        while (self.index < self.source.len) {
-            const c = self.source[self.index];
-            if (c == CARRIAGE_RETURN or c == LINE_FEED) {
-                break;
-            }
-            self.index += 1;
+        if (utils.simd.memchrCrOrLf(self.source[self.index..])) |pos| {
+            self.index += pos;
+        } else {
+            self.index = self.source.len;
+            return self.source[start..self.index];
         }
         const line = self.source[start..self.index];
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -182,17 +182,17 @@ pub fn main(init: std.process.Init) !void {
     if (ctx.cfg.benchmark_all) debug.mark("show window");
     window.show();
 
-    if (ctx.cfg.start_timer) {
-        const elapsed = @as(f64, @floatFromInt(debug.monotonicNs() - ctx.start_ns)) / std.time.ns_per_ms;
-        log.info("appeared on screen in {d:.2}ms", .{elapsed});
-    }
-
     if (!skip_desktop) {
         const loaded = desktop_loader.load(init.gpa, ctx.cfg.benchmark_all, ctx.cfg.show_actions, ctx.cfg.actions_bottombar) catch |err| blk: {
             log.info("desktop load failed: {}", .{err});
             break :blk try init.gpa.alloc(ui.ListItem, 0);
         };
         window.setOwnedItems(loaded);
+    }
+
+    if (ctx.cfg.start_timer) {
+        const elapsed = @as(f64, @floatFromInt(debug.monotonicNs() - ctx.start_ns)) / std.time.ns_per_ms;
+        log.info("appeared on screen in {d:.2}ms", .{elapsed});
     }
 
     if (ctx.cfg.benchmark_all) debug.printBenchmarks();

--- a/src/main.zig
+++ b/src/main.zig
@@ -104,34 +104,35 @@ pub fn main(init: std.process.Init) !void {
 
     const use_menus = menu_entries.len > 0;
     const skip_desktop = use_menus or ctx.cfg.no_dapps;
-    const items = if (skip_desktop) blk: {
-        if (use_menus) {
-            var list_items = try std.ArrayList(ui.ListItem).initCapacity(init.gpa, menu_entries.len);
-            errdefer {
-                for (list_items.items) |item| {
-                    init.gpa.free(item.icon);
-                    init.gpa.free(item.cmd);
-                    init.gpa.free(item.name);
-                }
-                list_items.deinit(init.gpa);
+
+    var items: []ui.ListItem = undefined;
+    if (use_menus) {
+        var list_items = try std.ArrayList(ui.ListItem).initCapacity(init.gpa, menu_entries.len);
+        errdefer {
+            for (list_items.items) |item| {
+                init.gpa.free(item.icon);
+                init.gpa.free(item.cmd);
+                init.gpa.free(item.name);
             }
-            for (menu_entries) |me| {
-                const icon = try init.gpa.dupe(u8, me.icon);
-                errdefer init.gpa.free(icon);
-                const cmd = try init.gpa.dupe(u8, me.cmd);
-                errdefer init.gpa.free(cmd);
-                const name = try init.gpa.dupe(u8, me.name);
-                errdefer init.gpa.free(name);
-                list_items.appendAssumeCapacity(.{
-                    .icon = icon,
-                    .cmd = cmd,
-                    .name = name,
-                });
-            }
-            break :blk try list_items.toOwnedSlice(init.gpa);
+            list_items.deinit(init.gpa);
         }
-        break :blk try init.gpa.alloc(ui.ListItem, 0);
-    } else try desktop_loader.load(init.gpa, ctx.cfg.benchmark_all, ctx.cfg.show_actions, ctx.cfg.actions_bottombar);
+        for (menu_entries) |me| {
+            const icon = try init.gpa.dupe(u8, me.icon);
+            errdefer init.gpa.free(icon);
+            const cmd = try init.gpa.dupe(u8, me.cmd);
+            errdefer init.gpa.free(cmd);
+            const name = try init.gpa.dupe(u8, me.name);
+            errdefer init.gpa.free(name);
+            list_items.appendAssumeCapacity(.{
+                .icon = icon,
+                .cmd = cmd,
+                .name = name,
+            });
+        }
+        items = try list_items.toOwnedSlice(init.gpa);
+    } else {
+        items = try init.gpa.alloc(ui.ListItem, 0);
+    }
 
     defer {
         if (use_menus) {
@@ -141,17 +142,9 @@ pub fn main(init: std.process.Init) !void {
                 init.gpa.free(item.name);
             }
             init.gpa.free(items);
-        } else if (ctx.cfg.no_dapps) {
-            init.gpa.free(items);
         } else {
-            for (items) |item| {
-                init.gpa.free(item.icon);
-                init.gpa.free(item.cmd);
-                init.gpa.free(item.name);
-                if (item.actions.len > 0) desktop_loader.freeListItemActions(init.gpa, item.actions);
-            }
             init.gpa.free(items);
-            desktop_loader.freeDesktopApps();
+            if (!skip_desktop) desktop_loader.freeDesktopApps();
         }
     }
 
@@ -167,9 +160,6 @@ pub fn main(init: std.process.Init) !void {
     if (config.configDir(init.gpa)) |cfg_dir| {
         freq_store.load(cfg_dir);
         window.list.frequency_store = &freq_store;
-        if (!window.population_delayed) {
-            window.list.setFilter("");
-        }
         cfg_dir_opt = cfg_dir;
     } else |_| {}
     defer {
@@ -185,6 +175,10 @@ pub fn main(init: std.process.Init) !void {
         std.debug.print("  (dirty: {any})\n", .{freq_store.dirty});
     }
 
+    if (skip_desktop) {
+        window.list.setFilter("");
+    }
+
     if (ctx.cfg.benchmark_all) debug.mark("show window");
     window.show();
 
@@ -192,6 +186,15 @@ pub fn main(init: std.process.Init) !void {
         const elapsed = @as(f64, @floatFromInt(debug.monotonicNs() - ctx.start_ns)) / std.time.ns_per_ms;
         log.info("appeared on screen in {d:.2}ms", .{elapsed});
     }
+
+    if (!skip_desktop) {
+        const loaded = desktop_loader.load(init.gpa, ctx.cfg.benchmark_all, ctx.cfg.show_actions, ctx.cfg.actions_bottombar) catch |err| blk: {
+            log.info("desktop load failed: {}", .{err});
+            break :blk try init.gpa.alloc(ui.ListItem, 0);
+        };
+        window.setOwnedItems(loaded);
+    }
+
     if (ctx.cfg.benchmark_all) debug.printBenchmarks();
 
     if (ctx.cfg.start_timer and ctx.cfg.theme_reloader) styles_watcher.start(init.gpa);

--- a/src/ui/window.zig
+++ b/src/ui/window.zig
@@ -21,7 +21,6 @@ var g_fullscreen: bool = false;
 var g_monitor: ?i32 = null;
 var g_blur_timer: qt.QTimer = undefined;
 var g_mouse_left_at: i64 = 0;
-var g_populate_timer: qt.QTimer = undefined;
 var g_backdrop: ?QWidget = null;
 var g_backdrop_geo: [4]i32 = .{ 0, 0, 0, 0 };
 
@@ -49,10 +48,6 @@ fn onLeaveWidget(_: QWidget, _: qt.QEvent) callconv(.c) void {
 
 fn onBlurTimerTimeout(_: qt.QTimer) callconv(.c) void {
     QApp.Quit();
-}
-
-fn onPopulateTimerTimeout(_: qt.QTimer) callconv(.c) void {
-    g_window.list.setFilter("");
 }
 
 fn onBackdropClick(_: qt.QWidget, _: qt.QMouseEvent) callconv(.c) void {
@@ -86,7 +81,7 @@ pub const Window = struct {
     search_bar: SearchBar,
     list: List,
     bottom_bar: ?BottomBar,
-    population_delayed: bool,
+    owned_items: ?[]ListItem = null,
 
     pub fn init(
         self: *Window,
@@ -149,7 +144,6 @@ pub const Window = struct {
         }
 
         const is_launchpad = if (vis.theme) |t| std.mem.eql(u8, t, "launchpad") else false;
-        const population_delayed = is_launchpad;
 
         if (vis.fullscreen) {
             const cp = target_screen.Geometry();
@@ -189,9 +183,6 @@ pub const Window = struct {
 
         var list = List.fromItems(allocator, items, vis.icon_size);
         list.adoptGList();
-        if (!population_delayed) {
-            list.setFilter("");
-        }
 
         main_layout.AddWidget(list.view);
 
@@ -201,7 +192,6 @@ pub const Window = struct {
             .search_bar = search_bar,
             .list = list,
             .bottom_bar = null,
-            .population_delayed = population_delayed,
         };
 
         self.list.adoptGList();
@@ -263,6 +253,12 @@ pub const Window = struct {
         Keyboard.setup(window, &self.list, self.search_bar.widget);
     }
 
+    pub fn setOwnedItems(self: *Window, items: []ListItem) void {
+        self.owned_items = items;
+        self.list.source = .{ .items = items };
+        self.list.setFilter("");
+    }
+
     pub fn show(self: *Window) void {
         if (animation.config().enabled) {
             self.widget.SetWindowOpacity(0.0);
@@ -281,12 +277,6 @@ pub const Window = struct {
             self.widget.Show();
         }
         self.widget.Raise();
-        g_populate_timer = qt.QTimer.New();
-        g_populate_timer.SetSingleShot(true);
-        g_populate_timer.OnTimeout(onPopulateTimerTimeout);
-        if (self.population_delayed) {
-            g_populate_timer.Start(200);
-        }
         animation.animateFadeIn(self.widget);
     }
 
@@ -297,12 +287,26 @@ pub const Window = struct {
     pub fn deinit(self: *Window) void {
         g_blur_timer.Stop();
         g_blur_timer.Delete();
-        g_populate_timer.Stop();
-        g_populate_timer.Delete();
         closeBackdrop();
         self.search_bar.deinit();
         self.list.deinit();
         if (self.bottom_bar) |*bar| bar.deinit();
+        if (self.owned_items) |items| {
+            for (items) |item| {
+                self.allocator.free(item.icon);
+                self.allocator.free(item.cmd);
+                self.allocator.free(item.name);
+                if (item.actions.len > 0) {
+                    for (item.actions) |a| {
+                        self.allocator.free(a.name);
+                        self.allocator.free(a.exec);
+                        self.allocator.free(a.icon);
+                    }
+                    self.allocator.free(item.actions);
+                }
+            }
+            self.allocator.free(items);
+        }
         self.widget.Delete();
     }
 };

--- a/src/utils/simd.zig
+++ b/src/utils/simd.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+
+const V16 = @Vector(16, u8);
+
+pub fn memchrCrOrLf(data: []const u8) ?usize {
+    const cr: V16 = @splat(@as(u8, '\r'));
+    const lf: V16 = @splat(@as(u8, '\n'));
+
+    var offset: usize = 0;
+    while (offset + 16 <= data.len) : (offset += 16) {
+        const block: [16]u8 = data[offset..][0..16].*;
+        const bytes: V16 = block;
+        const matches = (bytes == cr) | (bytes == lf);
+        const any = @reduce(.Or, matches);
+        if (any) {
+            const arr: [16]bool = matches;
+            for (arr, 0..) |m, j| {
+                if (m) return offset + j;
+            }
+        }
+    }
+    return if (offset < data.len) brk: {
+        for (data[offset..], 0..) |b, j| {
+            if (b == '\r' or b == '\n') break :brk offset + j;
+        }
+        break :brk null;
+    } else null;
+}

--- a/src/utils/utils.zig
+++ b/src/utils/utils.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 pub const log = @import("log.zig");
 pub const fsutils = @import("fsutils.zig");
+pub const simd = @import("simd.zig");
 
 pub fn esc(allocator: std.mem.Allocator, s: []const u8) ![]const u8 {
     var buf2: std.ArrayList(u8) = .empty;


### PR DESCRIPTION
## Startup
- Window created with empty list and shown immediately (~38ms)
- `.desktop` file scanning/parsing deferred until after window is visible
- List populates asynchronously ~6ms later via `Window.setOwnedItems()`
- Total startup with dapps: ~43ms (was ~260ms)
- `--start-timer` / `--debug` now measures from process start to fully loaded and rendered
## Window lifecycle
- Removed `population_delayed` flag and populate timer (no longer needed)
- Window owns loaded list items via `owned_items` field, frees them in `deinit()`
- Added `setOwnedItems()` to swap items into the list model post-init
- Menu entries and `--no-dapps` still populate synchronously before show
## SIMD
- New `src/utils/simd.zig` module with `memchrCrOrLf` using `@Vector(16, u8)`
- Applied to `dapp_parser.LineIterator.next()` for newline scanning
- Stripped unused functions (`toLower`, `memchr`, etc.): only what's needed